### PR TITLE
Fix bug which cause errors when using STI classes

### DIFF
--- a/lib/acts_as_async/helper.rb
+++ b/lib/acts_as_async/helper.rb
@@ -40,6 +40,7 @@ module ActsAsAsync
       def inherited(subclass)
         queue = instance_variable_get(:@queue)
         subclass.instance_variable_set(:@queue, queue)
+        super
       end
     end
 


### PR DESCRIPTION
Found that when implementing acts_as_async in Ringadoc ;-)
