### PR TITLE
Support for new Resque Scheduler namespace

### DIFF
--- a/lib/acts_as_async.rb
+++ b/lib/acts_as_async.rb
@@ -7,7 +7,7 @@ require "resque"
 # Resque scheduler changed namespace, this probably isn't best way to support both old & new one but it's only way I can think of
 begin
   require "resque_scheduler"
-rescue
+rescue LoadError
   require "resque-scheduler"
 end
 

--- a/lib/acts_as_async.rb
+++ b/lib/acts_as_async.rb
@@ -3,7 +3,13 @@ require "active_support/concern"
 require "active_record"
 
 require "resque"
-require "resque_scheduler"
+
+# Resque scheduler changed namespace, this probably isn't best way to support both old & new one but it's only way I can think of
+begin
+  require "resque_scheduler"
+rescue
+  require "resque-scheduler"
+end
 
 require "acts_as_async/errors"
 require "acts_as_async/base_extensions"

--- a/lib/acts_as_async/railtie.rb
+++ b/lib/acts_as_async/railtie.rb
@@ -2,7 +2,11 @@ module ActsAsAsync
   class Railtie < Rails::Railtie
     rake_tasks do
       require "resque/tasks"
-      require "resque_scheduler/tasks"
+      begin
+        require "resque_scheduler/tasks"
+      rescue LoadError
+        require "resque/scheduler/tasks"
+      end
 
       task "resque:setup" => :environment
     end


### PR DESCRIPTION
In recent version of Resque Scheduler they changed namespace from resque_scheduler to resque/scheduler, I modified a bit require directives to be able work with both old & new one.
